### PR TITLE
Update for latest format of marathon constraints

### DIFF
--- a/pod_scheduling.go
+++ b/pod_scheduling.go
@@ -31,7 +31,7 @@ type PodUpgrade struct {
 
 // PodPlacement supports constraining which hosts a pod is placed on
 type PodPlacement struct {
-	Constraints           *[][]string `json:"constraints"`
+	Constraints           *[]Constraint `json:"constraints"`
 	AcceptedResourceRoles []string    `json:"acceptedResourceRoles,omitempty"`
 }
 
@@ -42,19 +42,26 @@ type PodSchedulingPolicy struct {
 	Placement *PodPlacement `json:"placement,omitempty"`
 }
 
+// Constraint describes the constraint for pod placement
+type Constraint struct {
+	FieldName  string `json:"fieldName"`
+	Operator   string `json:"operator"`
+	Value      string `json:"value,omitempty"`
+}
+
 // NewPodPlacement creates an empty PodPlacement
 func NewPodPlacement() *PodPlacement {
 	return &PodPlacement{
-		Constraints:           &[][]string{},
+		Constraints:           &[]Constraint{},
 		AcceptedResourceRoles: []string{},
 	}
 }
 
 // AddConstraint adds a new constraint
 //		constraints:	the constraint definition, one constraint per array element
-func (r *PodPlacement) AddConstraint(constraints ...string) *PodPlacement {
+func (r *PodPlacement) AddConstraint(constraint Constraint) *PodPlacement {
 	c := *r.Constraints
-	c = append(c, constraints)
+	c = append(c, constraint)
 	r.Constraints = &c
 
 	return r


### PR DESCRIPTION
Like whats [here](https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/public/api/v2/types/constraint.raml)

`make build test examples` is fine, tested with 710 and looks fine, PR on that ready to go once this has been merged.

@dfturn merge pls if you are happy with this.